### PR TITLE
Adding bad response JSON to KLOG

### DIFF
--- a/krestclient.cpp
+++ b/krestclient.cpp
@@ -344,6 +344,7 @@ KJSON KJsonRestClient::RequestAndParseResponse (KStringView sRequest, const KMIM
 	{
 		if (HttpSuccess())
 		{
+			kDebug(1, kFormat("Error while parsing response. Received sResponse: {}", sResponse));
 			// only throw on bad JSON if this is a 200 response, else return the
 			// primary error
 			return ThrowOrReturn (KHTTPError { KHTTPError::H5xx_ERROR, kFormat("bad rx json: {}", sError) });


### PR DESCRIPTION
We see what the error is that causes a bad parsing of a string to JSON, but we don't actually see the string itself when we hit a parsing error. This changes that.