### PR TITLE
Add 207 Multi-Status HTTP Response Status Code

### DIFF
--- a/khttperror.cpp
+++ b/khttperror.cpp
@@ -92,6 +92,7 @@ KStringView KHTTPError::GetStatusString(uint16_t iStatusCode)
 		case H2xx_CREATED:            return "CREATED";
 		case H2xx_ACCEPTED:           return "ACCEPTED";
 		case H2xx_NO_CONTENT:         return "NO CONTENT";
+		case H2xx_MULTI_STATUS:       return "MULTI-STATUS";
 		case H2xx_UPDATED:            return "UPDATED";
 		case H2xx_DELETED:            return "DELETED";
 		case H2xx_ALREADY:            return "ALREADY DONE";

--- a/khttperror.h
+++ b/khttperror.h
@@ -70,6 +70,7 @@ public:
 		H2xx_CREATED            = 201,
 		H2xx_ACCEPTED           = 202,
 		H2xx_NO_CONTENT         = 204,
+		H2xx_MULTI_STATUS       = 207,
 		H2xx_UPDATED            = 290,
 		H2xx_DELETED            = 291,
 		H2xx_ALREADY            = 292,

--- a/krestserver.cpp
+++ b/krestserver.cpp
@@ -1546,6 +1546,7 @@ void KRESTServer::SetStatus (int iCode)
 		case KHTTPError::H2xx_UPDATED:      Response.SetStatus (201, "UPDATED");                break;
 		case KHTTPError::H2xx_DELETED:      Response.SetStatus (201, "DELETED");                break;
 		case KHTTPError::H2xx_NO_CONTENT:   Response.SetStatus (204, "NO CONTENT");             break;
+		case KHTTPError::H2xx_MULTI_STATUS: Response.SetStatus (207, "MULTI-STATUS");           break;
 		case KHTTPError::H2xx_ALREADY:      Response.SetStatus (208, "ALREADY DONE");           break;
 
 		// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Adding this response code to allow for partially correct 200 success calls, for example, when 1000 segments are run through PUT /Xapis/SegmentTranslation, but 4 segments failed.

Reference link here: https://www.webfx.com/web-development/glossary/http-status-codes/what-is-a-207-status-code/