### PR TITLE
Fix off-by-one in HTTP suffix range (bytes=-N)

### DIFF
--- a/source/http/protocol/khttp_header.cpp
+++ b/source/http/protocol/khttp_header.cpp
@@ -166,8 +166,12 @@ std::vector<KHTTPHeader::Range> KHTTPHeader::GetRanges(KStringView sContent, std
 				{
 					if (!rp.second.empty())
 					{
-						iEnd   = std::min(iResourceEnd, rp.second.UInt64());
-						iStart = iResourceEnd - iEnd;
+						// "bytes=-N": the last N bytes. Clamp the suffix length to the
+						// resource *size* (not size-1) and offset from it, so that N >= size
+						// returns the whole resource and N < size returns exactly N bytes
+						// (using size-1 here returned N+1 bytes, off by one).
+						iEnd   = std::min(iResourceSize, rp.second.UInt64());
+						iStart = iResourceSize - iEnd;
 						iEnd   = iResourceEnd;
 					}
 					else

--- a/utests/khttp_header_tests.cpp
+++ b/utests/khttp_header_tests.cpp
@@ -148,4 +148,69 @@ TEST_CASE("KHTTPHeader")
 		sHeader = kFormat("{}: none", KHTTPHeader::CONTENT_TYPE);
 		CHECK ( sHeader == "content-type: none");
 	}
+
+	SECTION("GetRanges")
+	{
+		static constexpr uint64_t iSize = 1000; // valid byte offsets 0..999
+
+		// closed range
+		{
+			auto Ranges = KHTTPHeader::GetRanges("bytes=0-499", iSize);
+			REQUIRE ( Ranges.size() == 1 );
+			CHECK ( Ranges.front().GetStart() == 0   );
+			CHECK ( Ranges.front().GetEnd()   == 499 );
+			CHECK ( Ranges.front().GetSize()  == 500 );
+		}
+
+		// open ended range "start-"
+		{
+			auto Ranges = KHTTPHeader::GetRanges("bytes=500-", iSize);
+			REQUIRE ( Ranges.size() == 1 );
+			CHECK ( Ranges.front().GetStart() == 500 );
+			CHECK ( Ranges.front().GetEnd()   == 999 );
+			CHECK ( Ranges.front().GetSize()  == 500 );
+		}
+
+		// closed range with end past EOF is clamped to the last byte
+		{
+			auto Ranges = KHTTPHeader::GetRanges("bytes=900-5000", iSize);
+			REQUIRE ( Ranges.size() == 1 );
+			CHECK ( Ranges.front().GetStart() == 900 );
+			CHECK ( Ranges.front().GetEnd()   == 999 );
+			CHECK ( Ranges.front().GetSize()  == 100 );
+		}
+
+		// suffix range "-N" = the last N bytes (must be exactly N, not N+1)
+		{
+			auto Ranges = KHTTPHeader::GetRanges("bytes=-100", iSize);
+			REQUIRE ( Ranges.size() == 1 );
+			CHECK ( Ranges.front().GetStart() == 900 );
+			CHECK ( Ranges.front().GetEnd()   == 999 );
+			CHECK ( Ranges.front().GetSize()  == 100 );
+		}
+
+		// suffix equal to the resource size = the whole resource
+		{
+			auto Ranges = KHTTPHeader::GetRanges("bytes=-1000", iSize);
+			REQUIRE ( Ranges.size() == 1 );
+			CHECK ( Ranges.front().GetStart() == 0   );
+			CHECK ( Ranges.front().GetEnd()   == 999 );
+			CHECK ( Ranges.front().GetSize()  == 1000 );
+		}
+
+		// suffix larger than the resource = the whole resource (not a negative start)
+		{
+			auto Ranges = KHTTPHeader::GetRanges("bytes=-2000", iSize);
+			REQUIRE ( Ranges.size() == 1 );
+			CHECK ( Ranges.front().GetStart() == 0   );
+			CHECK ( Ranges.front().GetEnd()   == 999 );
+			CHECK ( Ranges.front().GetSize()  == 1000 );
+		}
+
+		// no Range header at all -> no ranges
+		{
+			auto Ranges = KHTTPHeader::GetRanges("", iSize);
+			CHECK ( Ranges.empty() );
+		}
+	}
 }


### PR DESCRIPTION
## Problem
`KHTTPHeader::GetRanges()` mishandles HTTP suffix ranges (`Range: bytes=-N`,
"the last N bytes"). It computed the start offset from the last byte index
(`iResourceSize - 1`) instead of the resource size, so `bytes=-N` resolved to
the last **N+1** bytes.

Example — 1000-byte resource, `Range: bytes=-100`:
- before: `bytes 899-999/1000` (101 bytes)
- after:  `bytes 900-999/1000` (100 bytes)

Hit while serving video over a KREST endpoint — a player's suffix-range probe
came back one byte long.

## Fix
Clamp the suffix length to the resource *size* and offset from it. This also
preserves the existing behaviour that `N >= size` returns the whole resource
(the naive `size-1`→`size` swap alone would drop the first byte in that case).

## Tests
Adds a `GetRanges` section to `utests/khttp_header_tests.cpp` covering closed,
open-ended, end-past-EOF (clamped), and suffix ranges including `N == size` and
`N > size`. Confirmed the suffix assertions fail on the pre-fix code (`899`/`101`)
and pass after.
(No AI-attribution line, per your convention.)